### PR TITLE
Remove the libmysql  dependency

### DIFF
--- a/ports/gdal/CONTROL
+++ b/ports/gdal/CONTROL
@@ -2,11 +2,6 @@ Source: gdal
 Version: 2.4.0
 Description: The Geographic Data Abstraction Library for reading and writing geospatial raster and vector data.
 Build-Depends: proj, libpng, geos, sqlite3, curl, expat, libpq, openjpeg, libwebp, libxml2, liblzma
-Default-Features: mysql-libmysql
-
-Feature: mysql-libmysql
-Build-Depends: libmysql
-Description: Add mysql support using libmysql
 
 Feature: mysql-libmariadb
 Build-Depends: libmariadb


### PR DESCRIPTION
The fact that it's not possible to build libmysql for x86 is a source of troubles for projects that have GDAL as a dependency. Though it's possible to build GDAL separately for x64 & x86 this is very confusing and breaks other builds. For example I'm often crossing this issue when trying to build a local GMT package. So the best is to just remove it as a dependency.

```
C:\programs\compa_libs\vcpkg>vcpkg install gmt:x86-windows --recurse
The following packages will be built and installed:
  * gdal[core,mysql-libmysql]:x86-windows
    gmt[core]:x86-windows
  * libmysql[core]:x86-windows
Additional packages (*) will be modified to complete this operation.
Starting package 1/3: libmysql:x86-windows
Building package libmysql[core]:x86-windows...
CMake Error at C:/programs/compa_libs/vcpkg/ports/libmysql/portfile.cmake:10 (message):
  Oracle has dropped support in libmysql for 32-bit Windows.
```